### PR TITLE
Renamed Twitter to X

### DIFF
--- a/src/app/constants/websiteSuggestions.ts
+++ b/src/app/constants/websiteSuggestions.ts
@@ -2,7 +2,7 @@ export const WEBSITE_SUGGESTIONS: string[] = [
   'facebook.com',
   'instagram.com',
   'youtube.com',
-  'twitter.com',
+  'x.com',
   'reddit.com',
   'messenger.com',
   'tiktok.com',


### PR DESCRIPTION
#### Description of what you did:

Twitter has been renamed to X, and the [twitter.com](https://twitter.com) url now redirects to [x.com](https://x.com). So it's better to add [x.com](https://x.com) to the block list because it will block the content even if the user clicks on an old twitter link.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature
